### PR TITLE
Update round_sdc

### DIFF
--- a/R/make_geojson.R
+++ b/R/make_geojson.R
@@ -42,6 +42,6 @@ round_sdc = function(x, threshold = 10, digits = 0) {
   sel_sdc = x < threshold & x > 0
   mean_sdc = mean(x[sel_sdc])
   x[sel_sdc] = mean_sdc
-  round(x, digits = digits)
+  max(round(x, digits = digits), 1)
 }
 


### PR DESCRIPTION
Hypothesis: `mean_sdc` was below 0.5 meaning that all values between 0 and 10 were being coerced to 0.

Now they will show as 1. This links to https://github.com/nptscot/npt/issues/149 on Statistical Disclosure Control (SDC)

Should fix this: #152 

Hopefully